### PR TITLE
Fix banner font consistency

### DIFF
--- a/components/CountdownBanner.tsx
+++ b/components/CountdownBanner.tsx
@@ -48,7 +48,7 @@ export default function CountdownBanner({ targetDate, eventName, lumaUrl }: Coun
         <span>
           {eventName} starts in
         </span>
-        <div className="font-mono text-xs bg-white dark:bg-neutral-900 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded border border-gray-200 dark:border-neutral-700">
+        <div className="text-xs bg-white dark:bg-neutral-900 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded border border-gray-200 dark:border-neutral-700">
           {timeLeft.days}d {String(timeLeft.hours).padStart(2, '0')}:{String(timeLeft.minutes).padStart(2, '0')}:{String(timeLeft.seconds).padStart(2, '0')}
         </div>
 


### PR DESCRIPTION
Remove `font-mono` class from CountdownBanner to match the site's typography.

---
<a href="https://cursor.com/background-agent?bcId=bc-441b43d3-e6d3-40dc-be9c-d4cde4c102fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-441b43d3-e6d3-40dc-be9c-d4cde4c102fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

