### PR TITLE
Add Cursor profile link to sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -37,6 +37,9 @@ export function Sidebar() {
           <a href="https://www.linkedin.com/in/alhwyn" target="_blank" rel="noopener noreferrer" className="block hover:underline">
             linkedin.com/alhwyn
           </a>
+          <a href="https://cursor.com/@alhwyn" target="_blank" rel="noopener noreferrer" className="block hover:underline">
+            cursor.com/@alhwyn
+          </a>
           <button
             type="button"
             onClick={handleCopy}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds https://cursor.com/@alhwyn to the sidebar links section, alongside the existing X, GitHub, and LinkedIn links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb98829e-c7b8-49a2-bb06-3c00f7d67c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb98829e-c7b8-49a2-bb06-3c00f7d67c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

