### PR TITLE
Fix SEO: sitemap, metadata, and structured data

### DIFF
--- a/app/hackathons/[id]/page.tsx
+++ b/app/hackathons/[id]/page.tsx
@@ -5,15 +5,21 @@ import { ArrowLeft } from "lucide-react";
 import ImageCarousel from "@/components/ImageCarousel";
 import VideoPlayer from "@/components/VideoPlayer";
 import MarkdownContent from "@/components/MarkdownContent";
+import { JsonLd } from "@/components/JsonLd";
 import { getContentBySlug, getContentSlugs } from "@/lib/content";
-
-// Valid hackathon slugs
-const validHackathonSlugs = ['slate', 'cursor-hackathon', 'scrapyard'];
+import {
+  PUBLIC_HACKATHON_SLUGS,
+  createPageMetadata,
+  eventJsonLd,
+  getContentDescription,
+} from "@/lib/seo";
 
 export async function generateStaticParams() {
-  const slugs = getContentSlugs('hackathons');
+  const slugs = getContentSlugs("hackathons");
   return slugs
-    .filter((slug) => validHackathonSlugs.includes(slug))
+    .filter((slug) =>
+      PUBLIC_HACKATHON_SLUGS.includes(slug as (typeof PUBLIC_HACKATHON_SLUGS)[number])
+    )
     .map((slug) => ({ id: slug }));
 }
 
@@ -25,13 +31,22 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   if (!data) {
     return {
       title: "Hackathon Not Found",
+      robots: { index: false, follow: false },
     };
   }
 
-  return {
+  const description = getContentDescription(
+    data.content,
+    `${data.frontmatter.title} — a hackathon organized by Alhwyn Geonzon`,
+    data.frontmatter
+  );
+
+  return createPageMetadata({
     title: data.frontmatter.title,
-    description: `Details for ${data.frontmatter.title}`,
-  };
+    description,
+    path: `/hackathons/${id}`,
+    type: "article",
+  });
 }
 
 export default async function HackathonPage({ params }: { params: Promise<{ id: string }> }) {
@@ -51,8 +66,22 @@ export default async function HackathonPage({ params }: { params: Promise<{ id: 
   const { frontmatter, content } = data;
   const { title, date, media, lumaEventId } = frontmatter;
 
+  const description = getContentDescription(
+    content,
+    `${title} — a hackathon organized by Alhwyn Geonzon`,
+    frontmatter
+  );
+
   return (
     <div className="min-h-screen bg-slate-50 text-black dark:bg-neutral-900 dark:text-neutral-400">
+      <JsonLd
+        data={eventJsonLd({
+          title,
+          description,
+          path: `/hackathons/${id}`,
+          date,
+        })}
+      />
       {/* Back button */}
       <div className="max-w-4xl mx-auto px-8 pt-12 pb-8">
         <Link

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,17 @@ import { AIChatProvider } from "@/contexts/AIChatContext";
 import { Sidebar } from "@/components/Sidebar";
 import { AISidebarProvider } from "@/components/AISidebarProvider";
 import { ContentWrapper } from "@/components/ContentWrapper";
+import { JsonLd } from "@/components/JsonLd";
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_OG_IMAGE,
+  DEFAULT_OG_IMAGE_HEIGHT,
+  DEFAULT_OG_IMAGE_WIDTH,
+  SITE_NAME,
+  SITE_URL,
+  personJsonLd,
+  websiteJsonLd,
+} from "@/lib/seo";
 import "./globals.css";
 
 const geistSans = Instrument_Serif({
@@ -19,56 +30,60 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://alhwyn.com'),
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: "Alhwyn Geonzon",
-    template: "%s | Alhwyn Geonzon"
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
   },
-  description: "Portfolio showing my projects and hackathons. Mix of games, AI stuff, and random builds—mostly things I shipped for fun or events around Victoria. I host events and hackathons.",
+  description: DEFAULT_DESCRIPTION,
   keywords: [
     "Alhwyn Geonzon",
     "Alhwyn",
+    "software developer",
+    "Victoria BC",
+    "hackathon organizer",
+    "portfolio",
   ],
-  authors: [{ name: "Alhwyn Geonzon" }],
-  creator: "Alhwyn Geonzon",
-  publisher: "Alhwyn Geonzon",
+  authors: [{ name: SITE_NAME, url: SITE_URL }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
   robots: {
     index: true,
     follow: true,
     googleBot: {
       index: true,
       follow: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
     },
   },
   openGraph: {
     type: "website",
     locale: "en_US",
-    url: "https://alhwyn.com",
-    siteName: "Alhwyn Geonzon Portfolio",
-    title: "Alhwyn Geonzon - Portfolio",
-    description: "Portfolio showing my projects and hackathons. Mix of games, AI stuff, and random builds—mostly things I shipped for fun or events around Victoria. I host events and hackathons.",
+    url: SITE_URL,
+    siteName: `${SITE_NAME} Portfolio`,
+    title: `${SITE_NAME} - Portfolio`,
+    description: DEFAULT_DESCRIPTION,
     images: [
       {
-        url: "/image/icon/photobob_icon.jpeg",
-        width: 1200,
-        height: 630,
-        alt: "Alhwyn Geonzon Portfolio",
+        url: DEFAULT_OG_IMAGE,
+        width: DEFAULT_OG_IMAGE_WIDTH,
+        height: DEFAULT_OG_IMAGE_HEIGHT,
+        alt: `${SITE_NAME} Portfolio`,
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Alhwyn Geonzon - Portfolio",
-    description: "Portfolio showing my projects and hackathons. Mix of games, AI stuff, and random builds—mostly things I shipped for fun or events around Victoria. I host events and hackathons.",
+    title: `${SITE_NAME} - Portfolio`,
+    description: DEFAULT_DESCRIPTION,
     site: "@alhwyn",
     creator: "@alhwyn",
-    images: ["/image/icon/photobob_icon.jpeg"],
+    images: [DEFAULT_OG_IMAGE],
   },
   alternates: {
-    canonical: "https://alhwyn.com",
+    canonical: SITE_URL,
   },
   category: "Technology",
   classification: "Portfolio Website",
@@ -84,6 +99,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-slate-50 dark:bg-neutral-900`}
       >
+        <JsonLd data={[personJsonLd(), websiteJsonLd()]} />
         <AIChatProvider>
           <Sidebar />
           <AISidebarProvider />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,12 @@
+import type { Metadata } from "next";
 import { Project, ProjectTimeline } from "../components/ProjectTimeline";
+import { createPageMetadata, DEFAULT_DESCRIPTION } from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Alhwyn Geonzon",
+  description: DEFAULT_DESCRIPTION,
+  path: "/",
+});
 import { Hackathon, HackathonTimeline } from "../components/HackathonList";
 import CountdownBanner from "@/components/CountdownBanner";
 import { getProjectsForTimeline } from "@/lib/projects";

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -4,16 +4,20 @@ import Link from "next/link";
 import ImageCarousel from "@/components/ImageCarousel";
 import VideoPlayer from "@/components/VideoPlayer";
 import MarkdownContent from "@/components/MarkdownContent";
+import { JsonLd } from "@/components/JsonLd";
 import { getContentBySlug, getContentSlugs } from "@/lib/content";
+import {
+  PUBLIC_PROJECT_SLUGS,
+  createPageMetadata,
+  creativeWorkJsonLd,
+  getContentDescription,
+} from "@/lib/seo";
 import { ArrowLeft } from "lucide-react";
 
-// Valid project slugs that map to MDX files
-const validProjectSlugs = ['photobomb', 'canlii-mcp', 'reeflog', 'dockbot'];
-
 export async function generateStaticParams() {
-  const slugs = getContentSlugs('projects');
+  const slugs = getContentSlugs("projects");
   return slugs
-    .filter((slug) => validProjectSlugs.includes(slug))
+    .filter((slug) => PUBLIC_PROJECT_SLUGS.includes(slug as (typeof PUBLIC_PROJECT_SLUGS)[number]))
     .map((slug) => ({ id: slug }));
 }
 
@@ -25,13 +29,22 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
   if (!data) {
     return {
       title: "Project Not Found",
+      robots: { index: false, follow: false },
     };
   }
 
-  return {
+  const description = getContentDescription(
+    data.content,
+    `${data.frontmatter.title} — a project by Alhwyn Geonzon`,
+    data.frontmatter
+  );
+
+  return createPageMetadata({
     title: data.frontmatter.title,
-    description: data.content.slice(0, 160),
-  };
+    description,
+    path: `/projects/${id}`,
+    type: "article",
+  });
 }
 
 export default async function ProjectPage({ params }: { params: Promise<{ id: string }> }) {
@@ -58,8 +71,22 @@ export default async function ProjectPage({ params }: { params: Promise<{ id: st
   const infoLabel2 = isHackathon ? "Role" : "Tools";
   const infoValue2 = isHackathon ? role : tools;
 
+  const description = getContentDescription(
+    content,
+    `${title} — a project by Alhwyn Geonzon`,
+    frontmatter
+  );
+
   return (
     <div className="min-h-screen bg-slate-50 text-black dark:bg-neutral-900 dark:text-neutral-400">
+      <JsonLd
+        data={creativeWorkJsonLd({
+          title,
+          description,
+          path: `/projects/${id}`,
+          date: year || date,
+        })}
+      />
       {/* Back button */}
       <div className="max-w-4xl mx-auto px-8 pt-12 pb-8">
         <Link

--- a/app/projects/archive/page.tsx
+++ b/app/projects/archive/page.tsx
@@ -1,5 +1,14 @@
+import type { Metadata } from "next";
 import { getProjectsForTimeline } from "@/lib/projects";
+import { createPageMetadata } from "@/lib/seo";
 import { ArchivePageClient } from "./ArchivePageClient";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Project Archive",
+  description:
+    "Archived projects by Alhwyn Geonzon, including CanLII MCP, ReefLog, and Dockbot.",
+  path: "/projects/archive",
+});
 
 const ARCHIVE_PROJECT_SLUGS = ["canlii-mcp", "reeflog", "dockbot"] as const;
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,21 +1,41 @@
-import { MetadataRoute } from 'next'
+import { MetadataRoute } from "next";
+import {
+  PUBLIC_HACKATHON_SLUGS,
+  PUBLIC_PROJECT_SLUGS,
+  SITE_URL,
+} from "@/lib/seo";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://alhwyn.com'
-  
+  const now = new Date();
+
+  const projectPages = PUBLIC_PROJECT_SLUGS.map((slug) => ({
+    url: `${SITE_URL}/projects/${slug}`,
+    lastModified: now,
+    changeFrequency: "monthly" as const,
+    priority: 0.8,
+  }));
+
+  const hackathonPages = PUBLIC_HACKATHON_SLUGS.map((slug) => ({
+    url: `${SITE_URL}/hackathons/${slug}`,
+    lastModified: now,
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
   return [
     {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: "weekly",
       priority: 1,
     },
-    // Add more pages as you create them
-    // {
-    //   url: `${baseUrl}/about`,
-    //   lastModified: new Date(),
-    //   changeFrequency: 'monthly',
-    //   priority: 0.8,
-    // },
-  ]
-} 
+    {
+      url: `${SITE_URL}/projects/archive`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    ...projectPages,
+    ...hackathonPages,
+  ];
+}

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,12 @@
+type JsonLdProps = {
+  data: Record<string, unknown> | Record<string, unknown>[];
+};
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,185 @@
+import type { Metadata } from "next";
+
+export const SITE_URL = "https://alhwyn.com";
+export const SITE_NAME = "Alhwyn Geonzon";
+export const DEFAULT_DESCRIPTION =
+  "Portfolio showing my projects and hackathons. Mix of games, AI stuff, and random builds—mostly things I shipped for fun or events around Victoria. I host events and hackathons.";
+
+export const DEFAULT_OG_IMAGE = "/image/icon/photobob_icon.jpeg";
+export const DEFAULT_OG_IMAGE_WIDTH = 1154;
+export const DEFAULT_OG_IMAGE_HEIGHT = 976;
+
+export const PUBLIC_PROJECT_SLUGS = [
+  "photobomb",
+  "canlii-mcp",
+  "reeflog",
+  "dockbot",
+] as const;
+
+export const PUBLIC_HACKATHON_SLUGS = [
+  "slate",
+  "cursor-hackathon",
+  "scrapyard",
+] as const;
+
+const SOCIAL_PROFILES = [
+  "https://x.com/alhwyn",
+  "https://github.com/Alhwyn",
+  "https://www.linkedin.com/in/alhwyn",
+  "https://cursor.com/@alhwyn",
+] as const;
+
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[#*_`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function truncateDescription(text: string, max = 160): string {
+  const plain = stripMarkdown(text);
+  if (plain.length <= max) return plain;
+  return `${plain.slice(0, max - 3).trimEnd()}...`;
+}
+
+export function getContentDescription(
+  content: string,
+  fallback: string,
+  frontmatter?: { project?: string; event?: string }
+): string {
+  if (frontmatter?.project) {
+    return truncateDescription(frontmatter.project);
+  }
+  if (frontmatter?.event) {
+    return truncateDescription(frontmatter.event);
+  }
+  if (content) {
+    const firstParagraph = content.split("\n\n")[0] ?? content;
+    return truncateDescription(firstParagraph);
+  }
+  return truncateDescription(fallback);
+}
+
+type PageMetadataOptions = {
+  title: string;
+  description: string;
+  path: string;
+  type?: "website" | "article";
+};
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+  type = "website",
+}: PageMetadataOptions): Metadata {
+  const url = path === "/" ? SITE_URL : `${SITE_URL}${path}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      type,
+      url,
+      title,
+      description,
+      images: [
+        {
+          url: DEFAULT_OG_IMAGE,
+          width: DEFAULT_OG_IMAGE_WIDTH,
+          height: DEFAULT_OG_IMAGE_HEIGHT,
+          alt: `${title} | ${SITE_NAME}`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [DEFAULT_OG_IMAGE],
+    },
+  };
+}
+
+export function personJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: SITE_NAME,
+    url: SITE_URL,
+    email: "alhwyn@alhwyn.com",
+    jobTitle: "Software Developer",
+    sameAs: [...SOCIAL_PROFILES],
+  };
+}
+
+export function creativeWorkJsonLd({
+  title,
+  description,
+  path,
+  date,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  date?: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CreativeWork",
+    name: title,
+    description,
+    url: `${SITE_URL}${path}`,
+    author: {
+      "@type": "Person",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+    ...(date ? { dateCreated: date } : {}),
+  };
+}
+
+export function eventJsonLd({
+  title,
+  description,
+  path,
+  date,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  date?: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: title,
+    description,
+    url: `${SITE_URL}${path}`,
+    organizer: {
+      "@type": "Person",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+    ...(date ? { startDate: date } : {}),
+  };
+}
+
+export function websiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: `${SITE_NAME} Portfolio`,
+    url: SITE_URL,
+    description: DEFAULT_DESCRIPTION,
+    author: {
+      "@type": "Person",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2043,7 +2043,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2054,7 +2053,6 @@
       "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2101,7 +2099,6 @@
       "integrity": "sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.0",
         "@typescript-eslint/types": "8.32.0",
@@ -2602,7 +2599,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3388,8 +3384,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -3627,7 +3622,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3801,7 +3795,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -6332,7 +6325,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
       "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.7",
         "@swc/helpers": "0.5.15",
@@ -6790,7 +6782,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6800,7 +6791,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7692,7 +7682,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7872,7 +7861,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8250,7 +8238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,7 +7,4 @@ Disallow: /_next/
 Disallow: /admin/
 
 # Sitemap location
-Sitemap: https://alhwyn.com/sitemap.xml
-
-# Crawl delay (optional, helps with server load)
-Crawl-delay: 1 
+Sitemap: https://alhwyn.com/sitemap.xml 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves technical SEO across the portfolio site so search engines and social previews can discover and index all public pages correctly.

## Changes

- **Shared SEO utilities** (`lib/seo.ts`): centralized site constants, description extraction from MDX content, metadata builder, and JSON-LD generators
- **Sitemap**: now includes homepage, archive, all 4 project pages, and all 3 hackathon pages (was homepage only)
- **Per-page metadata**: project, hackathon, archive, and home pages now get unique titles, descriptions, canonical URLs, Open Graph, and Twitter cards
- **Structured data**: Person + WebSite on the root layout; CreativeWork on project pages; Event on hackathon pages
- **Fixes**: corrected OG image dimensions (1154×976, not 1200×630); removed unsupported `Crawl-delay` from robots.txt

## Testing

- `npm run build` passes
- Sitemap generates 9 URLs (was 1)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6421f921-f2f8-469f-9753-f2c050f7c84d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6421f921-f2f8-469f-9753-f2c050f7c84d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

