### PR TITLE
Remove Gist Applications from portfolio

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -41,7 +41,7 @@ ${content}`;
 
   if (pathname === "/" || pathname === "") {
     return `Current page context: Portfolio home page (alhwyn.com)
-This is Alhwyn Geonzon's portfolio with projects and hackathons. Alhwyn is 19 and works as a software developer at Gist Applications in Victoria, Canada.`;
+This is Alhwyn Geonzon's portfolio with projects and hackathons. Alhwyn is 19 and works as a software developer based in Victoria, Canada.`;
   }
 
   return `Current page context: ${pathname || "Unknown page"}`;

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -41,7 +41,7 @@ ${content}`;
 
   if (pathname === "/" || pathname === "") {
     return `Current page context: Portfolio home page (alhwyn.com)
-This is Alhwyn Geonzon's portfolio with projects and hackathons. Alhwyn is 19 and works as a software developer based in Victoria, Canada.`;
+This is Alhwyn Geonzon's portfolio with projects and hackathons. Alhwyn works as a software developer based in Victoria, Canada.`;
   }
 
   return `Current page context: ${pathname || "Unknown page"}`;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ export default function Home() {
       <section className="relative min-h-screen w-full px-4 sm:px-8 py-8 sm:py-12 flex flex-col justify-center items-start gap-8 bg-slate-50 text-black dark:bg-neutral-900 dark:text-neutral-400">
           <div className="w-full max-w-3xl">
             <p className="text-base sm:text-lg text-gray-600 dark:text-neutral-400 leading-relaxed source-serif-4">
-              I&apos;m 19, a software developer based in Victoria, Canada. 
+              I&apos;m Alhwyn, a software developer based in Victoria, Canada. 
               I organize hackathons and build projects in my free time.
             </p>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,7 +71,7 @@ export default function Home() {
       <section className="relative min-h-screen w-full px-4 sm:px-8 py-8 sm:py-12 flex flex-col justify-center items-start gap-8 bg-slate-50 text-black dark:bg-neutral-900 dark:text-neutral-400">
           <div className="w-full max-w-3xl">
             <p className="text-base sm:text-lg text-gray-600 dark:text-neutral-400 leading-relaxed source-serif-4">
-              I&apos;m 19, a software developer in Gist Applications, based in Victoria, Canada. 
+              I&apos;m 19, a software developer based in Victoria, Canada. 
               I organize hackathons and build projects in my free time.
             </p>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes references to Gist Applications and age from the portfolio hero section and AI chat context.

**Changes:**
- Updated home page intro copy to: "I'm Alhwyn, a software developer based in Victoria, Canada."
- Updated chat API page context to match, so the AI assistant no longer mentions Gist Applications or age.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e873dca-22c4-4888-8a52-3f1c00ebd6cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e873dca-22c4-4888-8a52-3f1c00ebd6cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

