### PR TITLE
Fix mobile header navigation layout

### DIFF
--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -11,50 +11,86 @@ const externalLinkClass = `${navLinkClass} inline-block`;
 export function SiteHeader() {
   return (
     <header className="px-6 sm:px-10 lg:px-16 pt-8 pb-6">
-      <div className="mx-auto grid max-w-[1400px] grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-4">
-        <div className="col-span-2 sm:col-span-1">
+      <div className="mx-auto max-w-[1400px]">
+        <div className="flex flex-col gap-3 sm:grid sm:grid-cols-4 sm:gap-x-8 sm:gap-y-3">
           <Link href="/" className={nameClass}>
             alhwyn.com
           </Link>
-        </div>
 
-        <div className="flex flex-col gap-1">
-          <Link href="/events" className={navLinkClass}>
-            Events
-          </Link>
-        </div>
+          <nav
+            aria-label="Site"
+            className="flex flex-wrap gap-x-5 gap-y-2 sm:hidden"
+          >
+            <Link href="/events" className={navLinkClass}>
+              Events
+            </Link>
+            <Link href="/#work" className={navLinkClass}>
+              Work
+            </Link>
+            <a
+              href="https://github.com/alhwyn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={externalLinkClass}
+            >
+              Github
+            </a>
+            <a
+              href="https://www.linkedin.com/in/alhwyn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={externalLinkClass}
+            >
+              Linkedin
+            </a>
+            <a
+              href="https://x.com/alhwynn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={externalLinkClass}
+            >
+              X
+            </a>
+          </nav>
 
-        <div className="flex flex-col gap-1">
-          <Link href="/#work" className={navLinkClass}>
-            Work
-          </Link>
-          <a
-            href="https://github.com/alhwyn"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={externalLinkClass}
-          >
-            Github
-          </a>
-        </div>
+          <div className="hidden sm:flex sm:flex-col sm:gap-1">
+            <Link href="/events" className={navLinkClass}>
+              Events
+            </Link>
+          </div>
 
-        <div className="flex flex-col gap-1 sm:items-end">
-          <a
-            href="https://www.linkedin.com/in/alhwyn"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={externalLinkClass}
-          >
-            Linkedin
-          </a>
-          <a
-            href="https://x.com/alhwynn"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={externalLinkClass}
-          >
-            X
-          </a>
+          <div className="hidden sm:flex sm:flex-col sm:gap-1">
+            <Link href="/#work" className={navLinkClass}>
+              Work
+            </Link>
+            <a
+              href="https://github.com/alhwyn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={externalLinkClass}
+            >
+              Github
+            </a>
+          </div>
+
+          <div className="hidden sm:flex sm:flex-col sm:gap-1 sm:items-end">
+            <a
+              href="https://www.linkedin.com/in/alhwyn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={externalLinkClass}
+            >
+              Linkedin
+            </a>
+            <a
+              href="https://x.com/alhwynn"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={externalLinkClass}
+            >
+              X
+            </a>
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, the site header used a 2-column grid that scattered nav links across the left and right edges (Events on the left, Work/Github on the right, LinkedIn/X below on the left). This looked broken compared to the clean list layout used elsewhere on the page.

## Solution

- **Mobile (< sm):** Stack the site name on top, then show all nav links in a single wrapping row with consistent horizontal spacing.
- **Desktop (≥ sm):** Keep the existing 4-column grid layout unchanged.

## Testing

- `npm run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f563c-2d32-778a-9522-dc6b3e64a5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f563c-2d32-778a-9522-dc6b3e64a5d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

